### PR TITLE
Update treasure-overlay-spinner.css

### DIFF
--- a/src/treasure-overlay-spinner.css
+++ b/src/treasure-overlay-spinner.css
@@ -103,7 +103,7 @@ treasure-overlay-spinner.treasure-overlay-spinner-active-remove {
   position: absolute;
   min-height: 50px;
   min-width: 50px;
-  z-index: 1;
+  z-index: 9;
   top: -9999999px;
   left: -9999999px;
   width: 100%;


### PR DESCRIPTION
Issue with boostrap components that are not covered with z-index: 1 as defined on css for treasure-overlay-spinner-container.
For example .input-group .form-control has z-index: 2 on boostrap.css.